### PR TITLE
Feature/144 Modifying the appearance of the finance pages

### DIFF
--- a/bike-erp/package-lock.json
+++ b/bike-erp/package-lock.json
@@ -3664,6 +3664,15 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6807,6 +6816,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -10115,6 +10130,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -15555,7 +15576,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16170,7 +16195,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/bike-erp/src/pages/PaymentHistory/PayableHistory.tsx
+++ b/bike-erp/src/pages/PaymentHistory/PayableHistory.tsx
@@ -7,7 +7,7 @@ import { connect } from "react-redux";
 import { BACKEND_URL } from "../../core/utils/config";
 
 // STYLING
-import { Button, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@material-ui/core";
+import { Button, Paper, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@material-ui/core";
 import useStyles from "./PayableHistoryStyle";
 
 /*
@@ -51,61 +51,63 @@ const PayableHistory = ({ account }: any) => {
         <Typography>{account.firstName + " " + account.lastName}</Typography>
         <Typography variant="caption">{account.email}</Typography>
       </div>
-      <div className={classes.dataContainer}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell className={classes.orderCell}>Order number</TableCell>
-              <TableCell className={classes.orderCell}>Date</TableCell>
-              <TableCell className={classes.orderCell}>Total</TableCell>
-              <TableCell className={classes.orderCell}>Details</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-          {
-             Object.keys(accountPayables).length !== 0 && Object.values(accountPayables).map((order: any) => (
-              <TableRow key={order.account_payable_id}>
-                <TableCell className={classes.orderCell}>{order.account_payable_id}</TableCell>
-                <TableCell className={classes.orderCell}>{order.payable_date.substring(0, 10)}</TableCell>
-                <TableCell className={classes.orderCell}>{"$" +order.total}</TableCell>
-                <TableCell className={classes.orderCell}>
-                  <Button color="primary" 
-                    onClick={() => getAccountSpecifics(order.account_payable_id)}
-                  >
-                    See More
-                  </Button>
-                </TableCell>
+      <Paper className={classes.place}>
+        <div className={classes.dataContainer}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell className={classes.tableHeader}>Order number</TableCell>
+                <TableCell className={classes.tableHeader}>Date</TableCell>
+                <TableCell className={classes.tableHeader}>Total</TableCell>
+                <TableCell className={classes.tableHeader}>Details</TableCell>
               </TableRow>
-            ))
-          }
-          </TableBody>
-        </Table>
-      </div>
-      <div>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell colSpan={3} className={classes.orderCell}>Order Details</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            <TableRow>
-              <TableCell className={classes.orderCell}>ID</TableCell>
-              <TableCell className={classes.orderCell}>Quantity</TableCell>
-              <TableCell className={classes.orderCell}>Cost</TableCell>
-            </TableRow>
+            </TableHead>
+            <TableBody>
             {
-              accountSpecifics !== {} && Object.values(accountSpecifics).map((item: any) => (
-                <TableRow key={item.transaction_id}>
-                  <TableCell className={classes.orderCell}>{item.component_id}</TableCell>
-                  <TableCell className={classes.orderCell}>{item.quantity_bought}</TableCell>
-                  <TableCell className={classes.orderCell}>{"$" + item.cost}</TableCell>
+              Object.keys(accountPayables).length !== 0 && Object.values(accountPayables).map((order: any) => (
+                <TableRow key={order.account_payable_id}>
+                  <TableCell className={classes.orderCell}>{order.account_payable_id}</TableCell>
+                  <TableCell className={classes.orderCell}>{order.payable_date.substring(0, 10)}</TableCell>
+                  <TableCell className={classes.orderCell}>{"$" +order.total}</TableCell>
+                  <TableCell className={classes.orderCell}>
+                    <Button color="primary" 
+                      onClick={() => getAccountSpecifics(order.account_payable_id)}
+                    >
+                      See More
+                    </Button>
+                  </TableCell>
                 </TableRow>
               ))
             }
-          </TableBody>
-        </Table>
-      </div>
+            </TableBody>
+          </Table>
+        </div>
+        <div>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell colSpan={3} className={classes.tableHeader}>Order Details</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell className={classes.orderCell}>ID</TableCell>
+                <TableCell className={classes.orderCell}>Quantity</TableCell>
+                <TableCell className={classes.orderCell}>Cost</TableCell>
+              </TableRow>
+              {
+                accountSpecifics !== {} && Object.values(accountSpecifics).map((item: any) => (
+                  <TableRow key={item.transaction_id}>
+                    <TableCell className={classes.orderCell}>{item.component_id}</TableCell>
+                    <TableCell className={classes.orderCell}>{item.quantity_bought}</TableCell>
+                    <TableCell className={classes.orderCell}>{"$" + item.cost}</TableCell>
+                  </TableRow>
+                ))
+              }
+            </TableBody>
+          </Table>
+        </div>
+      </Paper>
     </div>
   );
 }

--- a/bike-erp/src/pages/PaymentHistory/PayableHistory.tsx
+++ b/bike-erp/src/pages/PaymentHistory/PayableHistory.tsx
@@ -52,8 +52,8 @@ const PayableHistory = ({ account }: any) => {
         <Typography variant="caption">{account.email}</Typography>
       </div>
       <Paper className={classes.place}>
-        <div className={classes.dataContainer}>
-          <Table size="small">
+        <div>
+          <Table size="small" className={classes.dataContainer}>
             <TableHead>
               <TableRow>
                 <TableCell className={classes.tableHeader}>Order number</TableCell>
@@ -81,9 +81,7 @@ const PayableHistory = ({ account }: any) => {
             }
             </TableBody>
           </Table>
-        </div>
-        <div>
-          <Table size="small">
+          <Table size="small" className={classes.dataContainer}>
             <TableHead>
               <TableRow>
                 <TableCell colSpan={3} className={classes.tableHeader}>Order Details</TableCell>

--- a/bike-erp/src/pages/PaymentHistory/PayableHistoryStyle.ts
+++ b/bike-erp/src/pages/PaymentHistory/PayableHistoryStyle.ts
@@ -9,7 +9,8 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: 0,
     paddingBottom: 0,
     paddingLeft: 20,
-    paddingRight: 20
+    paddingRight: 20,
+    maxWidth: "70%",
   },
   userDetails: {
     textAlign: "right",
@@ -19,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
     paddingRight: 20
   },
   dataContainer: {
-    marginBottom: 20
+    marginBottom: 20,
   },
   orderCell: {
     border: 1,

--- a/bike-erp/src/pages/PaymentHistory/PayableHistoryStyle.ts
+++ b/bike-erp/src/pages/PaymentHistory/PayableHistoryStyle.ts
@@ -2,7 +2,6 @@ import { makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   payableHistory: {
-    maxWidth: 800,
     marginTop: 0,
     marginBottom: 0,
     marginLeft: "auto",
@@ -27,7 +26,29 @@ const useStyles = makeStyles((theme) => ({
     borderWidth: 1,
     borderColor: "black",
     borderStyle: "solid"
-  }
+  },
+  tableHeader: {
+    backgroundColor: "black",
+    color: "white",
+    padding: "7px",
+    border: 1,
+    borderWidth: 1,
+    borderColor: "black",
+    borderStyle: "solid",
+  },
+  place: {
+    maxHeight: "50px",
+    maxWeidth: "50px",
+    overflow: "auto",
+    [theme.breakpoints.down("sm")]: {
+      marginTop: "50px",
+      minHeight: "500px",
+    },
+    [theme.breakpoints.up("md")]: {
+      marginTop: "10px",
+      minHeight: "650px",
+    },
+  },
 }));
 
 export default useStyles;

--- a/bike-erp/src/pages/PaymentHistory/ReceivableHistory.tsx
+++ b/bike-erp/src/pages/PaymentHistory/ReceivableHistory.tsx
@@ -52,8 +52,8 @@ const ReceivableHistory = ({ account }: any) => {
         <Typography variant="caption">{account.email}</Typography>
       </div>
       <Paper className={classes.place}>
-        <div className={classes.dataContainer}>
-          <Table size="small">
+        <div>
+          <Table size="small" className={classes.dataContainer}>
             <TableHead>
               <TableRow>
                 <TableCell className={classes.tableHeader}>Order number</TableCell>
@@ -81,9 +81,7 @@ const ReceivableHistory = ({ account }: any) => {
             }
             </TableBody>
           </Table>
-        </div>
-        <div>
-          <Table size="small">
+          <Table size="small" className={classes.dataContainer}>
             <TableHead>
               <TableRow>
                 <TableCell colSpan={4} className={classes.tableHeader}>Order Details</TableCell>

--- a/bike-erp/src/pages/PaymentHistory/ReceivableHistory.tsx
+++ b/bike-erp/src/pages/PaymentHistory/ReceivableHistory.tsx
@@ -7,7 +7,7 @@ import { connect } from "react-redux";
 import { BACKEND_URL } from "../../core/utils/config";
 
 // STYLING
-import { Button, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@material-ui/core";
+import { Button, Paper, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@material-ui/core";
 import useStyles from "./ReceivableHistoryStyle";
 
 /*
@@ -51,65 +51,67 @@ const ReceivableHistory = ({ account }: any) => {
         <Typography>{account.firstName + " " + account.lastName}</Typography>
         <Typography variant="caption">{account.email}</Typography>
       </div>
-      <div className={classes.dataContainer}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell className={classes.orderCell}>Order number</TableCell>
-              <TableCell className={classes.orderCell}>Date</TableCell>
-              <TableCell className={classes.orderCell}>Total</TableCell>
-              <TableCell className={classes.orderCell}>Details</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-          {
-            Object.keys(accountReceivables).length !== 0 && Object.values(accountReceivables).map((order: any) => (
-              <TableRow key={order.account_receivable_id}>
-                <TableCell className={classes.orderCell}>{order.account_receivable_id}</TableCell>
-                <TableCell className={classes.orderCell}>{order.payable_date.substring(0, 10)}</TableCell>
-                <TableCell className={classes.orderCell}>{"$" +order.total}</TableCell>
-                <TableCell className={classes.orderCell}>
-                  <Button color="primary" 
-                    onClick={() => getAccountSpecifics(order.account_receivable_id)}
-                  >
-                    See More
-                  </Button>
-                </TableCell>
+      <Paper className={classes.place}>
+        <div className={classes.dataContainer}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell className={classes.tableHeader}>Order number</TableCell>
+                <TableCell className={classes.tableHeader}>Date</TableCell>
+                <TableCell className={classes.tableHeader}>Total</TableCell>
+                <TableCell className={classes.tableHeader}>Details</TableCell>
               </TableRow>
-            ))
-          }
-          </TableBody>
-        </Table>
-      </div>
-      <div>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell colSpan={4} className={classes.orderCell}>Order Details</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            <TableRow>
-              <TableCell className={classes.orderCell}>ID</TableCell>
-              <TableCell className={classes.orderCell}>Description</TableCell>
-              <TableCell className={classes.orderCell}>Quantity</TableCell>
-              <TableCell className={classes.orderCell}>Cost</TableCell>
-            </TableRow>
+            </TableHead>
+            <TableBody>
             {
-              accountSpecifics !== {} && Object.values(accountSpecifics).map((item: any) => (
-                <TableRow key={item.bike_id}>
-                  <TableCell className={classes.orderCell}>{item.bike_id}</TableCell>
+              Object.keys(accountReceivables).length !== 0 && Object.values(accountReceivables).map((order: any) => (
+                <TableRow key={order.account_receivable_id}>
+                  <TableCell className={classes.orderCell}>{order.account_receivable_id}</TableCell>
+                  <TableCell className={classes.orderCell}>{order.payable_date.substring(0, 10)}</TableCell>
+                  <TableCell className={classes.orderCell}>{"$" +order.total}</TableCell>
                   <TableCell className={classes.orderCell}>
-                    {item.size + " " + item.color + " " + item.grade + " grade bike"}
+                    <Button color="primary" 
+                      onClick={() => getAccountSpecifics(order.account_receivable_id)}
+                    >
+                      See More
+                    </Button>
                   </TableCell>
-                  <TableCell className={classes.orderCell}>{item.quantity}</TableCell>
-                  <TableCell className={classes.orderCell}>{"$" + item.price}</TableCell>
                 </TableRow>
               ))
             }
-          </TableBody>
-        </Table>
-      </div>
+            </TableBody>
+          </Table>
+        </div>
+        <div>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell colSpan={4} className={classes.tableHeader}>Order Details</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell className={classes.orderCell}>ID</TableCell>
+                <TableCell className={classes.orderCell}>Description</TableCell>
+                <TableCell className={classes.orderCell}>Quantity</TableCell>
+                <TableCell className={classes.orderCell}>Cost</TableCell>
+              </TableRow>
+              {
+                accountSpecifics !== {} && Object.values(accountSpecifics).map((item: any) => (
+                  <TableRow key={item.bike_id}>
+                    <TableCell className={classes.orderCell}>{item.bike_id}</TableCell>
+                    <TableCell className={classes.orderCell}>
+                      {item.size + " " + item.color + " " + item.grade + " grade bike"}
+                    </TableCell>
+                    <TableCell className={classes.orderCell}>{item.quantity}</TableCell>
+                    <TableCell className={classes.orderCell}>{"$" + item.price}</TableCell>
+                  </TableRow>
+                ))
+              }
+            </TableBody>
+          </Table>
+        </div>
+      </Paper>
     </div>
   );
 }

--- a/bike-erp/src/pages/PaymentHistory/ReceivableHistoryStyle.ts
+++ b/bike-erp/src/pages/PaymentHistory/ReceivableHistoryStyle.ts
@@ -9,7 +9,8 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: 0,
     paddingBottom: 0,
     paddingLeft: 20,
-    paddingRight: 20
+    paddingRight: 20,
+    maxWidth: "70%",
   },
   userDetails: {
     textAlign: "right",
@@ -19,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
     paddingRight: 20
   },
   dataContainer: {
-    marginBottom: 20
+    marginBottom: 20,
   },
   orderCell: {
     border: 1,

--- a/bike-erp/src/pages/PaymentHistory/ReceivableHistoryStyle.ts
+++ b/bike-erp/src/pages/PaymentHistory/ReceivableHistoryStyle.ts
@@ -2,7 +2,6 @@ import { makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   receivableHistory: {
-    maxWidth: 800,
     marginTop: 0,
     marginBottom: 0,
     marginLeft: "auto",
@@ -27,7 +26,29 @@ const useStyles = makeStyles((theme) => ({
     borderWidth: 1,
     borderColor: "black",
     borderStyle: "solid"
-  }
+  },
+  tableHeader: {
+    backgroundColor: "black",
+    color: "white",
+    padding: "7px",
+    border: 1,
+    borderWidth: 1,
+    borderColor: "black",
+    borderStyle: "solid",
+  },
+  place: {
+    maxHeight: "50px",
+    maxWeidth: "50px",
+    overflow: "auto",
+    [theme.breakpoints.down("sm")]: {
+      marginTop: "50px",
+      minHeight: "500px",
+    },
+    [theme.breakpoints.up("md")]: {
+      marginTop: "10px",
+      minHeight: "650px",
+    },
+  },
 }));
 
 export default useStyles;


### PR DESCRIPTION
Account payable

![Screen Shot 2021-03-29 at 12 48 52 PM](https://user-images.githubusercontent.com/55299067/112872291-32fb0700-908e-11eb-9342-18b7997944af.png)

Account receivable

![Screen Shot 2021-03-29 at 12 49 06 PM](https://user-images.githubusercontent.com/55299067/112872316-3bebd880-908e-11eb-8223-fcff7fcdbfc0.png)

The pages are responsive and the tables are scrollable along the x and y axis as they scale.

closes #144 
