### PR TITLE
Feature/157 Modified the UI of the user logs

### DIFF
--- a/bike-erp/backend/src/main/dao/UserLogDAO.ts
+++ b/bike-erp/backend/src/main/dao/UserLogDAO.ts
@@ -39,7 +39,7 @@ export class UserLogDAO{
         return new Promise<any>((resolve, rejects) => {
             const insert =
                 "INSERT INTO `user_logs` (`email`, `activity`, `timestamp`) VALUES ('" +
-                email + "', '" + activity + "', NOW());";
+                email + "', '" + activity + "', CONVERT_TZ(NOW(),'+00:00','-04:00'));";
             db.query(insert, (err) => {
                 if (err) {
                     rejects(err);

--- a/bike-erp/package-lock.json
+++ b/bike-erp/package-lock.json
@@ -3685,6 +3685,15 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6877,6 +6886,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -10218,6 +10233,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -15732,7 +15753,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16347,7 +16372,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/bike-erp/src/pages/Inventory/InventoryStyles.ts
+++ b/bike-erp/src/pages/Inventory/InventoryStyles.ts
@@ -28,12 +28,7 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: "bold",
     color: "white",
     background: "black",
-    [theme.breakpoints.down("sm")]: {
-      minWidth:"150px",
-    }, 
-  },
-  emptyCell: {
-    background: "white",
+    minWidth:"150px",
   },
   place: {
     maxHeight: "50px",

--- a/bike-erp/src/pages/UserLogs/UserLogs.tsx
+++ b/bike-erp/src/pages/UserLogs/UserLogs.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from "react";
 import { BACKEND_URL } from "../../core/utils/config";
 
 // STYLING
-import { Table, TableHead, TableBody, TableRow, TableCell } from "@material-ui/core";
+import { Table, TableHead, TableBody, TableRow, TableCell, Paper } from "@material-ui/core";
 import useStyles from "./UserLogsStyles";
 
 /*
@@ -32,32 +32,32 @@ const UserLogs: React.FC = () => {
         <br></br>
         <div className={styles.title}>User Logs</div>
         <br></br>
-        <Table size="small" className={styles.tableStyle}>
-          <TableHead className={styles.tableHead}>
-            <TableRow className={styles.topRow}>
-              <TableCell className={styles.emptyCell} />
-              <TableCell>Time</TableCell>
-              <TableCell>User</TableCell>
-              <TableCell>Activity</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {logTable.map((row) => (
-              <TableRow key={row.log_id}>
-                <TableCell className={styles.tableHead} />
-                <TableCell className={styles.innerTable}>
-                  {row.timestamp}
-                </TableCell>
-                <TableCell className={styles.innerTable}>
-                  {row.email}
-                </TableCell>
-                <TableCell className={styles.innerTable}>
-                  {row.activity}
-                </TableCell>
+        <Paper className={styles.place}>
+          <Table size="small" stickyHeader className={styles.tableStyle}>
+            <TableHead className={styles.tableHead}>
+              <TableRow>
+                <TableCell className={styles.topRow}>Time</TableCell>
+                <TableCell className={styles.topRow}>User</TableCell>
+                <TableCell className={styles.topRow}>Activity</TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {logTable.map((row) => (
+                <TableRow key={row.log_id}>
+                  <TableCell className={styles.innerTable}>
+                    {row.timestamp}
+                  </TableCell>
+                  <TableCell className={styles.innerTable}>
+                    {row.email}
+                  </TableCell>
+                  <TableCell className={styles.innerTable}>
+                    {row.activity}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
       </div>
     </React.Fragment>
   );

--- a/bike-erp/src/pages/UserLogs/UserLogsStyles.ts
+++ b/bike-erp/src/pages/UserLogs/UserLogsStyles.ts
@@ -1,33 +1,50 @@
 import { makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
-    title: {
-      textAlign: "center",
-      fontWeight: "bold",
-      fontFamily: "Inter",
-      fontSize: "64",
+  title: {
+    alignItems: "center",
+    textAlign: "center",
+    fontWeight: "bold",
+    fontSize: "200%",
+  },
+  background: {
+    background: "#DDDDDD",
+    paddingLeft: "10px",
+    paddingRight: "10px",
+  },
+  tableHead: {
+    backgroundColor: "black",
+    padding: "7px",
+  },
+  tableStyle: {
+    width: "100%",
+    marginLeft: "auto",
+    marginRight: "auto",
+  },
+  innerTable: {
+    background: "#FFFFFF",
+  },
+  topRow: {
+    fontWeight: "bold",
+    color: "white",
+    background: "black",
+    minWidth:"150px",
+  },
+  place: {
+    maxHeight: "50px",
+    width: "70%",
+    marginLeft: "auto",
+    marginRight: "auto",
+    overflow: "auto",
+    [theme.breakpoints.down("sm")]: {
+      marginTop: "50px",
+      minHeight: "500px",
     },
-    background: {
-      background: "#DDDDDD",
+    [theme.breakpoints.up("md")]: {
+      marginTop: "10px",
+      minHeight: "650px",
     },
-    tableHead: {
-      background: "#BFBFBF",
-    },
-    tableStyle: {
-      width: "60%",
-      marginLeft: "auto",
-      marginRight: "auto",
-    },
-    innerTable: {
-      background: "#FFFFFF",
-    },
-    topRow: {
-      fontWeight: "bold",
-      fontFamily: "Inter",
-    },
-    emptyCell: {
-      background: "#DDDDDD",
-    },
-  }));
+  },
+}));
 
 export default useStyles;

--- a/bike-erp/src/test/Inventory/__snapshots__/Inventory.test.tsx.snap
+++ b/bike-erp/src/test/Inventory/__snapshots__/Inventory.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Inventory matches the snapshot 1`] = `
   </div>
   <br />
   <div
-    className="MuiPaper-root makeStyles-place-8 MuiPaper-elevation1 MuiPaper-rounded"
+    className="MuiPaper-root makeStyles-place-7 MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
       className="MuiTable-root makeStyles-tableStyle-4 MuiTable-stickyHeader"

--- a/bike-erp/src/test/UserLogs/__snapshots__/UserLogs.test.tsx.snap
+++ b/bike-erp/src/test/UserLogs/__snapshots__/UserLogs.test.tsx.snap
@@ -12,50 +12,49 @@ exports[`UserLogs matches the snapshot 1`] = `
     User Logs
   </div>
   <br />
-  <table
-    className="MuiTable-root makeStyles-tableStyle-4"
-    role={null}
+  <div
+    className="MuiPaper-root makeStyles-place-7 MuiPaper-elevation1 MuiPaper-rounded"
   >
-    <thead
-      className="MuiTableHead-root makeStyles-tableHead-3"
+    <table
+      className="MuiTable-root makeStyles-tableStyle-4 MuiTable-stickyHeader"
       role={null}
     >
-      <tr
-        className="MuiTableRow-root makeStyles-topRow-6 MuiTableRow-head"
+      <thead
+        className="MuiTableHead-root makeStyles-tableHead-3"
         role={null}
       >
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head makeStyles-emptyCell-7 MuiTableCell-sizeSmall"
-          scope="col"
-        />
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
-          scope="col"
+        <tr
+          className="MuiTableRow-root MuiTableRow-head"
+          role={null}
         >
-          Time
-        </th>
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
-          scope="col"
-        >
-          User
-        </th>
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
-          scope="col"
-        >
-          Activity
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      className="MuiTableBody-root"
-      role={null}
-    />
-  </table>
+          <th
+            aria-sort={null}
+            className="MuiTableCell-root MuiTableCell-head makeStyles-topRow-6 MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
+            scope="col"
+          >
+            Time
+          </th>
+          <th
+            aria-sort={null}
+            className="MuiTableCell-root MuiTableCell-head makeStyles-topRow-6 MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
+            scope="col"
+          >
+            User
+          </th>
+          <th
+            aria-sort={null}
+            className="MuiTableCell-root MuiTableCell-head makeStyles-topRow-6 MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
+            scope="col"
+          >
+            Activity
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        className="MuiTableBody-root"
+        role={null}
+      />
+    </table>
+  </div>
 </div>
 `;


### PR DESCRIPTION
Modified the UI of the User log page to make it match the rest of the pages. It is also responsive.

In desktop view:
![Screen Shot 2021-04-04 at 11 45 17 PM](https://user-images.githubusercontent.com/55299067/113534966-18e68a80-95a0-11eb-9442-b583e158e798.png)

In iPhone X view:
![UserLog_demo](https://user-images.githubusercontent.com/55299067/113534932-00767000-95a0-11eb-9c31-60440bdb7d45.gif)

This PR also fixes the timezone issue of the insert statement of the user log. It now inserts using the current timezone (EDT).

![Screen_Shot_2021-04-04_at_11 27 24_PM](https://user-images.githubusercontent.com/55299067/113535215-d07b9c80-95a0-11eb-9979-2fbb60f1fa83.png)




closes #157 